### PR TITLE
Remove backgroundColor from UIImageView in PZPhotoView

### DIFF
--- a/Classes/PZPhotoView.m
+++ b/Classes/PZPhotoView.m
@@ -159,8 +159,6 @@
     [self.imageView addGestureRecognizer:twoFingerTap];
     [self.imageView addGestureRecognizer:doubleTwoFingerTap];
     
-    self.imageView.backgroundColor = [UIColor greenColor];
-    
     self.contentSize = self.imageView.frame.size;
     
     [self setMaxMinZoomScalesForCurrentBounds];


### PR DESCRIPTION
Removed default background color of imageview used in PZPhotoView since it seems like a debug setting.
